### PR TITLE
Simple FreeBSD Port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,13 @@
-SHELL = /bin/bash
-KDIR=/lib/modules/`uname -r`/build # installed by 'kernel-default-devel'
-MDIR=$(shell pwd)
+#
 
-obj-m := hpilo.o
+.PATH:	${SRCTOP}/sys/dev/hpilo
 
-all: build
+KMOD	= hpilo
+SRCS	= hpilo.c
+SRCS	+= hpilo.h hpilo_port.h
 
-build:
-	make -C $(KDIR) M=$(MDIR) modules 
+SRCS+=  ${LINUXKPI_GENSRCS}
 
-buildc: clean build
+CFLAGS+= -I${SRCTOP}/sys/compat/linuxkpi/common/include
 
-clean:
-	make -C $(KDIR) M=$(MDIR) clean
-
-premake:
-	make -C $(KDIR) oldconfig
-	make -C $(KDIR) prepare
-	make -C $(KDIR) scripts
-	make -C $(KDIR) modules_prepare
-
-ilorest: insmod
-	sudo ilorest login
-
-# .ONESHELL will not break make for fail return recipe 
-.ONESHELL:
-insmod: build
-	@lsmod|grep hpilo > /dev/null && echo 'remove existing hpilo' && sudo rmmod hpilo
-	@sudo insmod $(MDIR)/hpilo.ko && echo "$(MDIR)/hpilo.ko inserted"
-	
-test: ilorest
-
-restore:
-	@sudo rmmod hpilo
-	@sudo modprobe hpilo
-
-help:
-	make -C $(KDIR) M=$(MDIR) help
-
+.include <bsd.kmod.mk>

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,15 @@ SRCS+=  ${LINUXKPI_GENSRCS}
 
 CFLAGS+= -I${SRCTOP}/sys/compat/linuxkpi/common/include
 
+# Remember to do `make cleandepend` if changing KERNCONF!
+KERNCONF?=    GENERIC
+KERNCONFDIR=  /usr/src/sys/${MACHINE_ARCH}/conf
+.if !empty(KERNCONF)
+SRCS+=        ${.OBJDIR}/.kconf/opt_global.h
+CFLAGS+=      -include ${.OBJDIR}/.kconf/opt_global.h
+.endif
+
+${.OBJDIR}/.kconf/opt_global.h: ${KERNCONFDIR}/${KERNCONF}
+	cd ${KERNCONFDIR} && config -d ${.OBJDIR}/.kconf ${KERNCONF}
+
 .include <bsd.kmod.mk>

--- a/README.freebsd
+++ b/README.freebsd
@@ -1,0 +1,18 @@
+We have developed patches for the hpilo driver so that it will compile as an
+"out of tree" driver on FreeBSD 13 & 14.
+
+It will load and with the help of linux compatibility models, ilorest runs
+nicely. We are able to interact with ilo and bios settings, as well as upgrade
+the systems firwmare.
+
+Thanks to HPE, this is dual licensed so others can build on this work and
+polish it for easier use.
+
+# Linux compatibility layer. Needed for ilorest
+mkdir -p /compat/linux/proc
+mount -t linprocfs linprocfs /compat/linux/proc
+mkdir -p /compat/linux/sys
+mount -t linsysfs linsysfs /compat/linux/sys
+mkdir -p /compat/linux/dev/shm
+mount -t tmpfs tmpfs /compat/linux/dev/shm
+touch /compat/linux/etc/ld.so.cache

--- a/hpilo.c
+++ b/hpilo.c
@@ -399,12 +399,6 @@ static inline int is_db_reset(int db_out)
 	return db_out & (1 << DB_RESET);
 }
 
-static inline int is_device_reset(struct ilo_hwinfo *hw)
-{
-	/* check for global reset condition */
-	return is_db_reset(get_device_outbound(hw));
-}
-
 static inline void clear_pending_db(struct ilo_hwinfo *hw, int clr)
 {
 	iowrite32(clr, &hw->mmio_vaddr[DB_OUT]);

--- a/hpilo.c
+++ b/hpilo.c
@@ -265,6 +265,7 @@ static int ilo_ccb_setup(struct ilo_hwinfo *hw, struct ccb_data *data, int slot)
 	char *dma_va;
 	dma_addr_t dma_pa;
 	struct ilo_ccb *driver_ccb, *ilo_ccb;
+	int err;
 
 	driver_ccb = &data->driver_ccb;
 	ilo_ccb = &data->ilo_ccb;
@@ -272,6 +273,12 @@ static int ilo_ccb_setup(struct ilo_hwinfo *hw, struct ccb_data *data, int slot)
 	data->dma_size = 2 * fifo_sz(NR_QENTRY) +
 			 2 * desc_mem_sz(NR_QENTRY) +
 			 ILO_START_ALIGN + ILO_CACHE_SZ;
+
+	err = dma_set_mask(&hw->ilo_dev->dev, 0xffffffffUL);
+	if (err) {
+		dev_err(&hw->ilo_dev->dev, "Could not set dma mask:%d\n", err);
+		return err;
+	}
 
 	data->dma_va = dma_alloc_coherent(&hw->ilo_dev->dev, data->dma_size,
 					  &data->dma_pa, GFP_ATOMIC);

--- a/hpilo.c
+++ b/hpilo.c
@@ -11,7 +11,6 @@
 #include <linux/fs.h>
 #include <linux/pci.h>
 #include <linux/interrupt.h>
-#include <linux/ioport.h>
 #include <linux/device.h>
 #include <linux/file.h>
 #include <linux/cdev.h>
@@ -24,6 +23,7 @@
 #include <linux/poll.h>
 #include <linux/slab.h>
 #include "hpilo.h"
+#include "hpilo_port.h"
 
 static struct class *ilo_class;
 static unsigned int ilo_major;
@@ -919,7 +919,7 @@ static void __exit ilo_exit(void)
 	class_destroy(ilo_class);
 }
 
-MODULE_VERSION("1.5.0");
+// MODULE_VERSION("1.5.0");
 MODULE_ALIAS(ILO_NAME);
 MODULE_DESCRIPTION(ILO_NAME);
 MODULE_AUTHOR("David Altobelli <david.altobelli@hp.com>");

--- a/hpilo.c
+++ b/hpilo.c
@@ -684,9 +684,9 @@ static irqreturn_t ilo_isr(int irq, void *data)
 
 static void ilo_unmap_device(struct pci_dev *pdev, struct ilo_hwinfo *hw)
 {
-	pci_iounmap(pdev, hw->db_vaddr);
-	pci_iounmap(pdev, hw->ram_vaddr);
-	pci_iounmap(pdev, hw->mmio_vaddr);
+	hpilo_pci_iounmap(pdev, hw->db_vaddr);
+	hpilo_pci_iounmap(pdev, hw->ram_vaddr);
+	hpilo_pci_iounmap(pdev, hw->mmio_vaddr);
 }
 
 static int ilo_map_device(struct pci_dev *pdev, struct ilo_hwinfo *hw)
@@ -697,7 +697,7 @@ static int ilo_map_device(struct pci_dev *pdev, struct ilo_hwinfo *hw)
 	int rc;
 
 	/* map the memory mapped i/o registers */
-	hw->mmio_vaddr = pci_iomap(pdev, 1, 0);
+	hw->mmio_vaddr = hpilo_pci_iomap(pdev, 1, 0);
 	if (hw->mmio_vaddr == NULL) {
 		dev_err(&pdev->dev, "Error mapping mmio\n");
 		goto out;
@@ -725,7 +725,7 @@ static int ilo_map_device(struct pci_dev *pdev, struct ilo_hwinfo *hw)
 	}
 
 	/* map the doorbell aperture */
-	hw->db_vaddr = pci_iomap(pdev, 3, max_ccb * ONE_DB_SIZE);
+	hw->db_vaddr = hpilo_pci_iomap(pdev, 3, max_ccb * ONE_DB_SIZE);
 	if (hw->db_vaddr == NULL) {
 		dev_err(&pdev->dev, "Error mapping doorbell\n");
 		goto ram_free;
@@ -733,9 +733,9 @@ static int ilo_map_device(struct pci_dev *pdev, struct ilo_hwinfo *hw)
 
 	return 0;
 ram_free:
-	pci_iounmap(pdev, hw->ram_vaddr);
+	hpilo_pci_iounmap(pdev, hw->ram_vaddr);
 mmio_free:
-	pci_iounmap(pdev, hw->mmio_vaddr);
+	hpilo_pci_iounmap(pdev, hw->mmio_vaddr);
 out:
 	return -ENOMEM;
 }
@@ -884,10 +884,10 @@ static int ilo_probe(struct pci_dev *pdev,
 
 	for (minor = 0 ; minor < max_ccb; minor++) {
 		error = hpilo_add_cdev(ilo_hw, devnum, minor);
-	if (error) {
+		if (error) {
 			dev_err(&pdev->dev, "Could not add cdev %d\n", minor);
 			goto remove_dev;
-	}
+		}
 	}
 
 	return 0;

--- a/hpilo.h
+++ b/hpilo.h
@@ -78,7 +78,7 @@ struct ilo_hwinfo {
  */
 #define ILOSW_CCB_SZ	64
 #define ILOHW_CCB_SZ 	128
-struct ccb {
+struct ilo_ccb {
 	union {
 		char *send_fifobar;
 		u64 send_fifobar_pa;
@@ -131,13 +131,13 @@ struct ccb {
  */
 struct ccb_data {
 	/* software version of ccb, using virtual addrs */
-	struct ccb  driver_ccb;
+	struct ilo_ccb  driver_ccb;
 
 	/* hardware version of ccb, using physical addrs */
-	struct ccb  ilo_ccb;
+	struct ilo_ccb  ilo_ccb;
 
 	/* hardware ccb is written to this shared mapped device memory */
-	struct ccb __iomem *mapped_ccb;
+	struct ilo_ccb __iomem *mapped_ccb;
 
 	/* dma'able memory used for send/recv queues */
 	void       *dma_va;

--- a/hpilo.h
+++ b/hpilo.h
@@ -61,7 +61,7 @@ struct ilo_hwinfo {
 	spinlock_t alloc_lock;
 	spinlock_t fifo_lock;
 
-	struct cdev cdev;
+	struct cdev cdev[MAX_CCB];
 };
 
 /* offset from mmio_vaddr for enabling doorbell interrupts */

--- a/hpilo_port.h
+++ b/hpilo_port.h
@@ -30,12 +30,31 @@ pci_match_id(const struct pci_device_id *ids, struct pci_dev *dev)
 }
 
 static inline void *
+hpilo_pci_iomap(struct pci_dev *dev, int mmio_bar, int mmio_size __unused)
+{
+	unsigned long addr, len;
+
+	addr = pci_resource_start(dev, mmio_bar);
+	len = pci_resource_len(dev, mmio_bar);
+	if (!addr)
+		return NULL;
+
+	return ioremap(addr, len);
+}
+
+static inline void
+hpilo_pci_iounmap(struct pci_dev *dev, void *res)
+{
+	iounmap(res);
+}
+
+static inline void *
 pci_iomap_range(struct pci_dev *dev, int bar, unsigned long offset,
 		unsigned long maxlen)
 {
 	void *vaddr;
 
-	vaddr = pci_iomap(dev, bar, maxlen);
+	vaddr = hpilo_pci_iomap(dev, bar, maxlen);
 	if (vaddr)
 		vaddr = (caddr_t)vaddr + offset;
 	return vaddr;

--- a/hpilo_port.h
+++ b/hpilo_port.h
@@ -1,0 +1,44 @@
+
+#define PCI_DEVICE_SUB(_vendor, _device, _subvendor, _subdevice)	\
+	.vendor = (_vendor), .device = (_device),			\
+	.subvendor = (_subvendor), .subdevice = (_subdevice)
+
+#define PCI_VENDOR_ID_HP_3PAR		0x1590
+#define PCI_VENDOR_ID_COMPAQ            0x0e11
+#define PCI_REVISION_ID           0x08    /* Revision ID */
+
+#define EPOLLIN			POLLIN		/* x01 */
+#define EPOLLERR		POLLERR		/* x08 */
+#define EPOLLRDNORM		POLLRDNORM	/* x40 */
+
+#define MODULE_ALIAS(x)
+
+#define MATCH(_id, _dev, _idfld, _devfld) \
+	(_id->_idfld == PCI_ANY_ID || _id->_idfld == _dev->_devfld)
+
+static int
+pci_match_id(const struct pci_device_id *ids, struct pci_dev *dev)
+{
+	for (; ids->vendor; ids++) {
+		if (MATCH(ids, dev, vendor, vendor) &&
+		    MATCH(ids, dev, device, device) &&
+		    MATCH(ids, dev, subvendor, subsystem_vendor) &&
+		    MATCH(ids, dev, subdevice, subsystem_device))
+			return 1;
+	}
+	return 0;
+}
+
+static inline void *
+pci_iomap_range(struct pci_dev *dev, int bar, unsigned long offset,
+		unsigned long maxlen)
+{
+	void *vaddr;
+
+	vaddr = pci_iomap(dev, bar, maxlen);
+	if (vaddr)
+		vaddr = (caddr_t)vaddr + offset;
+	return vaddr;
+}
+
+MODULE_DEPEND(hpilo, linuxkpi, 1, 1, 1);

--- a/hpilo_port.h
+++ b/hpilo_port.h
@@ -41,4 +41,13 @@ pci_iomap_range(struct pci_dev *dev, int bar, unsigned long offset,
 	return vaddr;
 }
 
+static inline int
+hpilo_make_dev(struct make_dev_args *args, struct cdev *ptr, char *name)
+{
+#pragma push_macro("cdev")
+#undef cdev
+	return make_dev_s(args, &ptr->cdev, "%s", name);
+#pragma pop_macro("cdev")
+}
+
 MODULE_DEPEND(hpilo, linuxkpi, 1, 1, 1);


### PR DESCRIPTION
We have created a set of patches which allow this driver to be compiled and used on FreeBSD. It loads and works correctly from Gen9 through Gen11 (ilo4 through ilo6) and _ilorest_ works via Linux Binary Compatibility. _ilorest_ is able to configure all aspects of the system and upgrade the ilo firmware.

In it's current form it's probably not suitable for inclusion in FreeBSD, nor do these patches create a single source tree from which both Linux and FreeBSD can be compiled. However by contributing this code on a branch, we hope to inspire further work towards a driver included in FreeBSD.